### PR TITLE
Limiting the operative arm rotation

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,4 +29,9 @@ public final class Constants {
   public static final double armZRotRate = 0.1;//The maximum rate at which the arm rotates when the motor is engaged
   public static final double armZRotRatio = 1.0;//How much the arm rotates PER ROTATION of the arm rotation gear
   public static final double maxPlatformAngle = 15.0;
+  public static final double[][] operativeRange = {
+    {1/4*Math.PI, 3/4*Math.PI},
+    {5/4*Math.PI, 7/4*Math.PI}
+  };//Operative rotation range in RADIANS
+  //THESE NUMBERS WILL NEED TO BE CHANGED ONCE WE DETERMINE THE CORRECT OPERATIVE RANGE
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -132,7 +132,12 @@ public class Robot extends TimedRobot {
     // Call the DriveSystem.drive() method with the speed and direction joystick values
     //Drive.drive(RobotContainer.speed, RobotContainer.direction);
     // Call the ArmSystem.turnArm() method with the arm rotation value
-    ArmControl.turnArm(RobotContainer.armZRot);
+
+      if((ArmControl.getArmRot()>Constants.operativeRange[0][0]&&ArmControl.getArmRot()<Constants.operativeRange[0][1])||(ArmControl.getArmRot()>Constants.operativeRange[1][0]&&ArmControl.getArmRot()<Constants.operativeRange[1][1])){
+        ArmControl.turnArm(RobotContainer.armZRot);
+      }else if(!forwardExtendSwitch.get()){
+        ArmControl.turnArm(RobotContainer.armZRot);
+      }
     //disabled while extension is not finished
     ArmControl.armDeflection(RobotContainer.armDeflect);
     SolenoidControl.solenoidControl(RobotContainer.clawEngaged);


### PR DESCRIPTION
Creates an operative range for the arm turning: it can only turn freely within 45 degrees and 135 degrees (the front of the robot) and 225 and 315 (the back of the robot. Otherwise, the arm must be pulled in fully in order to rotate